### PR TITLE
Upgrade Midnight Wallet SDK from v1.0.0 to v2.0.0

### DIFF
--- a/MIGRATION_GUIDE_SDK_2.0.md
+++ b/MIGRATION_GUIDE_SDK_2.0.md
@@ -1,0 +1,829 @@
+# Midnight Wallet SDK Migration Guide: v1.0.0 to v2.0.0
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Package Version Reference](#package-version-reference)
+- [Docker Image Updates](#docker-image-updates)
+- [WalletFacade Initialization (Critical)](#walletfacade-initialization-critical)
+- [Unified Configuration](#unified-configuration)
+- [Address Handling (Critical)](#address-handling-critical)
+- [Dust Wallet Renames](#dust-wallet-renames)
+- [Proving Decoupled from Wallets](#proving-decoupled-from-wallets)
+- [Submission Service](#submission-service)
+- [Pending Transactions Service](#pending-transactions-service)
+- [Automatic Transaction Reversion](#automatic-transaction-reversion)
+- [Shielded Wallet Changes](#shielded-wallet-changes)
+- [Unshielded Wallet Changes](#unshielded-wallet-changes)
+- [Abstractions Changes](#abstractions-changes)
+- [Indexer Client Changes](#indexer-client-changes)
+- [Dust Registration and Deregistration](#dust-registration-and-deregistration)
+- [WASM Proving (New)](#wasm-proving-new)
+- [Complete Initialization Example](#complete-initialization-example)
+- [Migration Checklist](#migration-checklist)
+- [Known Issues](#known-issues)
+
+---
+
+## Overview
+
+The 2.0.0 release is a major architectural overhaul focused on **decoupling services** from individual wallets into standalone, facade-owned services. The three pillars of this release are:
+
+1. **Proving extracted** into a standalone `ProvingService` - no longer a wallet-level concern
+2. **Submission extracted** into a standalone `SubmissionService` - with automatic revert on failure
+3. **Pending transaction monitoring** via new `PendingTransactionsService` - tracks TTL, detects failures, auto-reverts
+4. **Standardized wallet APIs** - consistent naming across shielded, unshielded, and dust wallets
+5. **Typed addresses** - `ShieldedAddress`, `UnshieldedAddress`, `DustAddress` replace raw strings
+
+---
+
+## Package Version Reference
+
+| Package | v1.0.0 | v2.0.0 |
+|---------|--------|--------|
+| `@midnight-ntwrk/wallet-sdk-facade` | 1.0.0 | **2.0.0** |
+| `@midnight-ntwrk/wallet-sdk-abstractions` | 1.0.0 | **2.0.0** |
+| `@midnight-ntwrk/wallet-sdk-shielded` | 1.0.0 | **2.0.0** |
+| `@midnight-ntwrk/wallet-sdk-dust-wallet` | 1.0.0 | **2.0.0** |
+| `@midnight-ntwrk/wallet-sdk-unshielded-wallet` | 1.0.0 | **2.0.0** |
+| `@midnight-ntwrk/wallet-sdk-capabilities` | _(new)_ | **3.1.0** |
+| `@midnight-ntwrk/wallet-sdk-address-format` | 3.0.0 | **3.0.1** |
+| `@midnight-ntwrk/wallet-sdk-hd` | 3.0.0 | **3.0.1** |
+| `@midnight-ntwrk/wallet-sdk-prover-client` | _(new)_ | **1.1.0** |
+| `@midnight-ntwrk/wallet-sdk-indexer-client` | _(new)_ | **1.1.0** |
+| `@midnight-ntwrk/ledger-v7` | 7.0.0 | **7.0.2** |
+
+---
+
+## Docker Image Updates
+
+| Image | v1.0.0 | v2.0.0 |
+|-------|--------|--------|
+| `midnightntwrk/midnight-node` | 0.20.0 | **0.21.0** |
+| `midnightntwrk/indexer-standalone` | 3.0.0 | **3.1.0** |
+| `midnightntwrk/proof-server` | 7.0.0 | **7.0.0** (unchanged) |
+
+---
+
+## WalletFacade Initialization (Critical)
+
+This is the single most impactful breaking change. The `WalletFacade` constructor is now **private**. You must use the static async `WalletFacade.init()` method.
+
+### Before (v1.0.0)
+
+```typescript
+import { WalletFacade } from '@midnight-ntwrk/wallet-sdk-facade';
+
+// Create each wallet with its own config
+const shieldedWallet = ShieldedWallet(shieldedConfig).startWithSecretKeys(shieldedSecretKeys);
+const unshieldedWallet = UnshieldedWallet(unshieldedConfig).startWithPublicKey(publicKey);
+const dustWallet = DustWallet(dustConfig).startWithSecretKey(dustSecretKey, dustParams);
+
+// Pass wallets directly to constructor
+const facade = new WalletFacade(shieldedWallet, unshieldedWallet, dustWallet);
+await facade.start(shieldedSecretKeys, dustSecretKey);
+```
+
+### After (v2.0.0)
+
+```typescript
+import { type DefaultConfiguration, WalletFacade } from '@midnight-ntwrk/wallet-sdk-facade';
+
+// Single unified configuration for all wallets
+const configuration: DefaultConfiguration = {
+  networkId: 'undeployed',
+  indexerClientConnection: {
+    indexerHttpUrl: 'http://localhost:8088/api/v3/graphql',
+    indexerWsUrl: 'ws://localhost:8088/api/v3/graphql/ws',
+  },
+  provingServerUrl: new URL('http://localhost:6300'),
+  relayURL: new URL('ws://localhost:9944'),
+  costParameters: {
+    additionalFeeOverhead: 300_000_000_000_000n,
+    feeBlocksMargin: 5,
+  },
+  txHistoryStorage: new InMemoryTransactionHistoryStorage(),
+};
+
+// Pass wallet builder functions — config is forwarded automatically
+const facade = await WalletFacade.init({
+  configuration,
+  shielded: (cfg) => ShieldedWallet(cfg).startWithSecretKeys(shieldedSecretKeys),
+  unshielded: (cfg) => UnshieldedWallet(cfg).startWithPublicKey(publicKey),
+  dust: (cfg) => DustWallet(cfg).startWithSecretKey(dustSecretKey, dustParams),
+  // Optional: custom proving service (defaults to HTTP prover using provingServerUrl)
+  // provingService: (cfg) => makeWasmProvingService(),
+});
+await facade.start(shieldedSecretKeys, dustSecretKey);
+```
+
+### Key differences
+
+- **No more separate configs** — a single `DefaultConfiguration` is shared by all wallet builders
+- **Builder functions receive config** — the `(cfg) =>` pattern lets each builder extract what it needs
+- **Services are auto-created** — `SubmissionService`, `ProvingService`, and `PendingTransactionsService` are created internally by default
+- **`wallet.start()` is still required** after `init()`
+
+### DefaultConfiguration type
+
+```typescript
+type DefaultConfiguration =
+  DefaultUnshieldedConfiguration &    // networkId, indexerClientConnection, txHistoryStorage
+  DefaultShieldedConfiguration &      // networkId, indexerClientConnection, relayURL
+  DefaultDustConfiguration &          // networkId, indexerClientConnection, costParameters, relayURL
+  DefaultSubmissionConfiguration &    // relayURL
+  DefaultPendingTransactionsServiceConfiguration &  // indexerClientConnection, costParameters
+  Partial<DefaultProvingConfiguration>;             // provingServerUrl (optional if custom service provided)
+```
+
+---
+
+## Unified Configuration
+
+### Before (v1.0.0) — Three separate config objects
+
+```typescript
+const shieldedConfig = {
+  networkId: config.networkId,
+  indexerClientConnection: { indexerHttpUrl: config.indexer, indexerWsUrl: config.indexerWS },
+  provingServerUrl: new URL(config.proofServer),
+  relayURL,
+};
+
+const unshieldedConfig = {
+  networkId: config.networkId,
+  indexerClientConnection: { indexerHttpUrl: config.indexer, indexerWsUrl: config.indexerWS },
+  txHistoryStorage: new InMemoryTransactionHistoryStorage(),
+};
+
+const dustConfig = {
+  networkId: config.networkId,
+  costParameters: { additionalFeeOverhead: 300_000_000_000_000n, feeBlocksMargin: 5 },
+  indexerClientConnection: { indexerHttpUrl: config.indexer, indexerWsUrl: config.indexerWS },
+  provingServerUrl: new URL(config.proofServer),
+  relayURL,
+};
+```
+
+### After (v2.0.0) — One unified configuration
+
+```typescript
+const configuration: DefaultConfiguration = {
+  networkId: config.networkId,
+  indexerClientConnection: {
+    indexerHttpUrl: config.indexer,
+    indexerWsUrl: config.indexerWS,
+  },
+  provingServerUrl: new URL(config.proofServer),
+  relayURL: new URL(config.node.replace(/^http/, 'ws')),
+  costParameters: {
+    additionalFeeOverhead: 300_000_000_000_000n,
+    feeBlocksMargin: 5,
+  },
+  txHistoryStorage: new InMemoryTransactionHistoryStorage(),
+};
+```
+
+---
+
+## Address Handling (Critical)
+
+In v1.0.0, addresses were plain strings (Bech32-encoded). In v2.0.0, they are **typed objects**: `ShieldedAddress`, `UnshieldedAddress`, `DustAddress`.
+
+### Transfers — Before (v1.0.0)
+
+```typescript
+// Encode address to string manually
+const receiverAddress = recipientKeystore.getBech32Address().asString();
+
+wallet.transferTransaction(
+  [{
+    type: 'unshielded',
+    outputs: [{
+      type: ledger.nativeToken().raw,
+      receiverAddress,  // string
+      amount: 50_000n,
+    }],
+  }],
+  { shieldedSecretKeys, dustSecretKey },
+  { ttl },
+);
+```
+
+### Transfers — After (v2.0.0)
+
+```typescript
+// Get typed address from the wallet API
+const receiverAddress = await recipientWallet.unshielded.getAddress();  // UnshieldedAddress
+
+wallet.transferTransaction(
+  [{
+    type: 'unshielded',
+    outputs: [{
+      type: ledger.nativeToken().raw,
+      receiverAddress,  // UnshieldedAddress (typed)
+      amount: 50_000n,
+    }],
+  }],
+  { shieldedSecretKeys, dustSecretKey },
+  { ttl },
+);
+```
+
+### Parsing Bech32 strings to typed addresses
+
+If you receive an address as a Bech32 string (e.g. from user input), parse it:
+
+```typescript
+import { MidnightBech32m, UnshieldedAddress } from '@midnight-ntwrk/wallet-sdk-address-format';
+
+const parsed = MidnightBech32m.parse('mn_addr_undeployed1...');
+const unshieldedAddress = UnshieldedAddress.codec.decode(networkId, parsed);
+```
+
+### Display — encoding typed addresses to strings
+
+For display, you can still encode typed addresses to Bech32 strings:
+
+```typescript
+import { MidnightBech32m } from '@midnight-ntwrk/wallet-sdk-address-format';
+
+// From typed address to string
+const bech32 = MidnightBech32m.encode(networkId, state.shielded.address).asString();
+
+// Keystore still provides a convenience method for unshielded
+const unshieldedStr = keystore.getBech32Address().asString();
+```
+
+### Getting addresses from wallet APIs
+
+Each wallet type now has a `getAddress()` method:
+
+```typescript
+const shieldedAddr: ShieldedAddress = await wallet.shielded.getAddress();
+const unshieldedAddr: UnshieldedAddress = await wallet.unshielded.getAddress();
+const dustAddr: DustAddress = await wallet.dust.getAddress();
+```
+
+### Type definitions
+
+```typescript
+// TokenTransfer now requires typed addresses
+interface TokenTransfer<AddressType extends ShieldedAddress | UnshieldedAddress> {
+  type: ledger.RawTokenType;
+  receiverAddress: AddressType;  // was: string
+  amount: bigint;
+}
+
+type ShieldedTokenTransfer = {
+  type: 'shielded';
+  outputs: TokenTransfer<ShieldedAddress>[];
+};
+
+type UnshieldedTokenTransfer = {
+  type: 'unshielded';
+  outputs: TokenTransfer<UnshieldedAddress>[];
+};
+
+type CombinedTokenTransfer = ShieldedTokenTransfer | UnshieldedTokenTransfer;
+```
+
+---
+
+## Dust Wallet Renames
+
+All dust-prefixed names have been simplified for consistency across wallet types.
+
+### State properties
+
+| v1.0.0 | v2.0.0 |
+|--------|--------|
+| `state.dust.walletBalance(new Date())` | `state.dust.balance(new Date())` |
+| `state.dust.dustPublicKey` | `state.dust.publicKey` |
+| `state.dust.dustAddress` | `state.dust.address` |
+
+### API methods
+
+| v1.0.0 | v2.0.0 |
+|--------|--------|
+| `wallet.dust.getDustPublicKey()` | `wallet.dust.getPublicKey()` |
+| `wallet.dust.getDustAddress()` | `wallet.dust.getAddress()` |
+| `wallet.dust.proveTransaction()` | **Removed** — proving handled by facade |
+
+### Types
+
+| v1.0.0 | v2.0.0 |
+|--------|--------|
+| `DustCoreWallet` | `CoreWallet` |
+| `dustReceiverAddress: string` | `dustReceiverAddress: DustAddress` |
+
+### Example
+
+```typescript
+// Before
+const dustBalance = state.dust?.walletBalance(new Date()) ?? 0n;
+const dustPubKey = state.dust?.dustPublicKey;
+
+// After
+const dustBalance = state.dust?.balance(new Date()) ?? 0n;
+const dustPubKey = state.dust?.publicKey;
+```
+
+---
+
+## Proving Decoupled from Wallets
+
+In v1.0.0, proving was configured per-wallet via builder methods. In v2.0.0, proving is a **facade-level service**.
+
+### What was removed
+
+- `ShieldedWallet(config).withProving(...)` — **removed**
+- `ShieldedWallet(config).withProvingDefaults(...)` — **removed**
+- `DustWallet(config).withProving(...)` — **removed**
+- `DustWallet(config).withProvingDefaults(...)` — **removed**
+- `finalizeTransaction()` on `ShieldedWalletAPI` — **removed**
+- `proveTransaction()` on `DustWalletAPI` — **removed**
+- `Proving` export from `@midnight-ntwrk/wallet-sdk-shielded/v1` — **removed**
+- `provingService` parameter in V1 builders — **removed**
+- `UnboundTransaction` export from facade — **moved**
+
+### Where things moved
+
+| What | Old location | New location |
+|------|-------------|-------------|
+| `ProvingService` | N/A (internal) | `@midnight-ntwrk/wallet-sdk-capabilities/proving` |
+| `UnboundTransaction` | `@midnight-ntwrk/wallet-sdk-facade` | `@midnight-ntwrk/wallet-sdk-capabilities/proving` |
+| `makeDefaultProvingService` | N/A | `@midnight-ntwrk/wallet-sdk-capabilities/proving` |
+
+### How proving works now
+
+```typescript
+// DEFAULT: HTTP prover — just set provingServerUrl in configuration
+const wallet = await WalletFacade.init({
+  configuration: {
+    ...config,
+    provingServerUrl: new URL('http://localhost:6300'),  // <-- this is enough
+  },
+  shielded: ...,
+  unshielded: ...,
+  dust: ...,
+  // provingService omitted → uses HTTP prover at provingServerUrl
+});
+
+// CUSTOM: provide your own proving service
+import { makeWasmProvingService } from '@midnight-ntwrk/wallet-sdk-capabilities';
+
+const wallet = await WalletFacade.init({
+  configuration,  // no provingServerUrl needed
+  shielded: ...,
+  unshielded: ...,
+  dust: ...,
+  provingService: () => makeWasmProvingService(),
+});
+```
+
+### Transaction proving and finalization
+
+The `WalletFacade` now owns the `finalizeTransaction()` method, which:
+
+1. Calls `provingService.prove(tx)` to produce an `UnboundTransaction`
+2. Binds it to get a `FinalizedTransaction`
+3. Registers it with `PendingTransactionsService`
+4. On failure: **automatically reverts** across all three wallet types
+
+```typescript
+// The flow remains the same from the consumer perspective:
+const recipe = await wallet.transferTransaction(outputs, secretKeys, options);
+const signed = await wallet.signRecipe(recipe, signFn);
+const finalized = await wallet.finalizeRecipe(signed);   // proving happens here
+const txId = await wallet.submitTransaction(finalized);  // submission happens here
+```
+
+---
+
+## Submission Service
+
+Submission was extracted into a standalone service owned by the facade.
+
+### What changed
+
+- `WalletFacade.submitTransaction()` now delegates to an internal `SubmissionService`
+- On submission failure, the facade **automatically reverts** the transaction across all wallets
+- The service uses the `relayURL` from `DefaultConfiguration`
+
+### Custom submission service (optional)
+
+```typescript
+const wallet = await WalletFacade.init({
+  configuration,
+  submissionService: (config) => myCustomSubmissionService,
+  ...
+});
+```
+
+---
+
+## Pending Transactions Service
+
+This is a **new service** that monitors submitted transactions.
+
+### What it does
+
+1. Tracks transactions after finalization
+2. Monitors TTL expiration and indexer status
+3. Automatically reverts wallet state when a transaction fails
+4. Reports pending transaction state via `facadeState.pending`
+5. State is serializable — survives wallet restarts
+
+### Accessing pending state
+
+```typescript
+const state = await rx.firstValueFrom(wallet.state());
+console.log(state.pending);  // PendingTransactions<FinalizedTransaction>
+```
+
+### Custom service (optional)
+
+```typescript
+const wallet = await WalletFacade.init({
+  configuration,
+  pendingTransactionsService: (config) => myCustomService,
+  ...
+});
+```
+
+---
+
+## Automatic Transaction Reversion
+
+In v2.0.0, the facade handles failure at every step:
+
+| Failure point | v1.0.0 behavior | v2.0.0 behavior |
+|--------------|----------------|----------------|
+| Proving fails | Manual revert needed | Auto-reverts shielded + unshielded + dust |
+| Submission fails | Manual revert needed | Auto-reverts all wallets |
+| TTL expires | Not monitored | `PendingTransactionsService` detects and reverts |
+
+This means pending coins (booked for a transaction) are automatically released when any part of the pipeline fails.
+
+---
+
+## Shielded Wallet Changes
+
+### Removed
+
+| API | Reason |
+|-----|--------|
+| `finalizeTransaction()` | Proving moved to facade |
+| `startWithShieldedSeed()` | Renamed to `startWithSeed()` |
+| `Proving` export from `/v1` | Moved to capabilities package |
+| `withProving()` / `withProvingDefaults()` | Proving moved to facade |
+| `provingService` in V1 builder | Proving moved to facade |
+
+### Added
+
+```typescript
+// New method
+const address: ShieldedAddress = await wallet.shielded.getAddress();
+```
+
+### Changed
+
+- `receiverAddress` parameter: `string` → `ShieldedAddress`
+- Transaction history getter now throws "not yet implemented"
+- `DefaultV1Configuration` no longer includes `DefaultProvingConfiguration`
+
+---
+
+## Unshielded Wallet Changes
+
+### Transaction history enhancement
+
+Each `TransactionHistoryEntry` now includes coin data:
+
+```typescript
+interface TransactionHistoryEntry {
+  // ... existing fields ...
+  createdUtxos: Array<{
+    value: bigint;
+    owner: PublicKey;
+    tokenType: RawTokenType;
+    intentHash: string;
+    outputIndex: number;
+  }>;
+  spentUtxos: Array<{
+    value: bigint;
+    owner: PublicKey;
+    tokenType: RawTokenType;
+    intentHash: string;
+    outputIndex: number;
+  }>;
+}
+```
+
+### New method
+
+```typescript
+const address: UnshieldedAddress = await wallet.unshielded.getAddress();
+```
+
+### Bug fix
+
+- `rollbackSpendByUtxo` now handles missing UTXOs gracefully (returns state unchanged instead of throwing)
+
+---
+
+## Abstractions Changes
+
+### Moved
+
+- `SyncProgress` moved **from** `@midnight-ntwrk/wallet-sdk-shielded/v1` **to** `@midnight-ntwrk/wallet-sdk-abstractions`
+
+```typescript
+// Before
+import { SyncProgress } from '@midnight-ntwrk/wallet-sdk-shielded/v1';
+
+// After
+import { SyncProgress } from '@midnight-ntwrk/wallet-sdk-abstractions';
+```
+
+### Renamed
+
+- `SerializedUnprovenTransaction` → `SerializedTransaction`
+
+---
+
+## Indexer Client Changes
+
+### New: `keepAlive` configuration
+
+```typescript
+const configuration = {
+  indexerClientConnection: {
+    indexerHttpUrl: 'http://localhost:8088/api/v3/graphql',
+    indexerWsUrl: 'ws://localhost:8088/api/v3/graphql/ws',
+    keepAlive: 15_000,  // Optional, defaults to 15,000ms
+  },
+};
+```
+
+The `keepAlive` is forwarded to the underlying `graphql-ws` client. Useful for preventing service worker timer leaks.
+
+### New: Promise-based QueryRunner
+
+Execute GraphQL queries without Effect boilerplate:
+
+```typescript
+import { QueryRunner } from '@midnight-ntwrk/wallet-sdk-indexer-client';
+```
+
+---
+
+## Dust Registration and Deregistration
+
+### Registration (updated flow)
+
+The `registerNightUtxosForDustGeneration` method now returns an `UnprovenTransactionRecipe`:
+
+```typescript
+const recipe = await wallet.registerNightUtxosForDustGeneration(
+  nightUtxos,
+  unshieldedKeystore.getPublicKey(),
+  (payload) => unshieldedKeystore.signData(payload),
+  // Optional: dustReceiverAddress (DustAddress) — defaults to own address
+);
+
+// recipe.type === 'UNPROVEN_TRANSACTION'
+const finalized = await wallet.finalizeRecipe(recipe);
+const txId = await wallet.submitTransaction(finalized);
+```
+
+### Deregistration (new in v2.0.0)
+
+```typescript
+const recipe = await wallet.deregisterFromDustGeneration(
+  nightUtxos,
+  unshieldedKeystore.getPublicKey(),
+  (payload) => unshieldedKeystore.signData(payload),
+);
+
+// Balance and finalize
+const balanced = await wallet.balanceUnprovenTransaction(
+  recipe.transaction,
+  { shieldedSecretKeys, dustSecretKey },
+  { ttl: new Date(Date.now() + 30 * 60 * 1000), tokenKindsToBalance: ['dust'] },
+);
+
+const finalized = await wallet.finalizeRecipe(balanced);
+await wallet.submitTransaction(finalized);
+```
+
+### Redesignation (new in v2.0.0)
+
+Register your Night UTXOs to generate dust for a **different** wallet:
+
+```typescript
+const receiverDustAddress = receiverState.dust.address;  // DustAddress of target wallet
+
+const recipe = await senderWallet.registerNightUtxosForDustGeneration(
+  senderNightUtxos,
+  senderKeystore.getPublicKey(),
+  (payload) => senderKeystore.signData(payload),
+  receiverDustAddress,  // <-- designate dust to another address
+);
+
+const balanced = await senderWallet.balanceUnprovenTransaction(
+  recipe.transaction,
+  { shieldedSecretKeys, dustSecretKey },
+  { ttl, tokenKindsToBalance: ['dust'] },
+);
+
+const finalized = await senderWallet.finalizeRecipe(balanced);
+await senderWallet.submitTransaction(finalized);
+```
+
+### New flag on UTXOs
+
+```typescript
+// Check if a coin is already registered
+const unregistered = state.unshielded.availableCoins.filter(
+  (coin) => coin.meta.registeredForDustGeneration === false,
+);
+```
+
+---
+
+## WASM Proving (New)
+
+v2.0.0 adds WASM-based proving as an alternative to the HTTP proof server. Proofs are generated in a Web Worker.
+
+### Setup
+
+```typescript
+import { makeWasmProvingService } from '@midnight-ntwrk/wallet-sdk-capabilities';
+
+const wallet = await WalletFacade.init({
+  configuration: {
+    networkId: 'undeployed',
+    relayURL: new URL('ws://localhost:9944'),
+    indexerClientConnection: { ... },
+    costParameters: { ... },
+    txHistoryStorage: new InMemoryTransactionHistoryStorage(),
+    // No provingServerUrl needed!
+  },
+  shielded: (cfg) => ShieldedWallet(cfg).startWithSecretKeys(shieldedSecretKeys),
+  unshielded: (cfg) => UnshieldedWallet(cfg).startWithPublicKey(publicKey),
+  dust: (cfg) => DustWallet(cfg).startWithSecretKey(dustSecretKey, dustParams),
+  provingService: () => makeWasmProvingService(),
+});
+```
+
+### Notes
+
+- Uses Midnight-specific key material (not Filecoin keys)
+- Proof generation runs in a Web Worker to avoid blocking the main thread
+- No external proof server required
+- Suitable for browser-based wallets
+
+---
+
+## Complete Initialization Example
+
+Here is the full v2.0.0 initialization pattern, matching the official docs-snippets:
+
+```typescript
+import * as ledger from '@midnight-ntwrk/ledger-v7';
+import { DustWallet } from '@midnight-ntwrk/wallet-sdk-dust-wallet';
+import { type DefaultConfiguration, WalletFacade } from '@midnight-ntwrk/wallet-sdk-facade';
+import { HDWallet, Roles } from '@midnight-ntwrk/wallet-sdk-hd';
+import { ShieldedWallet } from '@midnight-ntwrk/wallet-sdk-shielded';
+import {
+  createKeystore,
+  InMemoryTransactionHistoryStorage,
+  PublicKey,
+  UnshieldedWallet,
+} from '@midnight-ntwrk/wallet-sdk-unshielded-wallet';
+import { Buffer } from 'buffer';
+
+const configuration: DefaultConfiguration = {
+  networkId: 'undeployed',
+  costParameters: {
+    additionalFeeOverhead: 300_000_000_000_000n,
+    feeBlocksMargin: 5,
+  },
+  relayURL: new URL('ws://localhost:9944'),
+  provingServerUrl: new URL('http://localhost:6300'),
+  indexerClientConnection: {
+    indexerHttpUrl: 'http://localhost:8088/api/v3/graphql',
+    indexerWsUrl: 'ws://localhost:8088/api/v3/graphql/ws',
+  },
+  txHistoryStorage: new InMemoryTransactionHistoryStorage(),
+};
+
+const initWalletWithSeed = async (seed: Buffer) => {
+  const hdWallet = HDWallet.fromSeed(seed);
+  if (hdWallet.type !== 'seedOk') throw new Error('Failed to initialize HDWallet');
+
+  const derivationResult = hdWallet.hdWallet
+    .selectAccount(0)
+    .selectRoles([Roles.Zswap, Roles.NightExternal, Roles.Dust])
+    .deriveKeysAt(0);
+
+  if (derivationResult.type !== 'keysDerived') throw new Error('Failed to derive keys');
+  hdWallet.hdWallet.clear();
+
+  const shieldedSecretKeys = ledger.ZswapSecretKeys.fromSeed(derivationResult.keys[Roles.Zswap]);
+  const dustSecretKey = ledger.DustSecretKey.fromSeed(derivationResult.keys[Roles.Dust]);
+  const unshieldedKeystore = createKeystore(
+    derivationResult.keys[Roles.NightExternal],
+    configuration.networkId,
+  );
+
+  const wallet = await WalletFacade.init({
+    configuration,
+    shielded: (cfg) => ShieldedWallet(cfg).startWithSecretKeys(shieldedSecretKeys),
+    unshielded: (cfg) =>
+      UnshieldedWallet(cfg).startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeystore)),
+    dust: (cfg) =>
+      DustWallet(cfg).startWithSecretKey(
+        dustSecretKey,
+        ledger.LedgerParameters.initialParameters().dust,
+      ),
+  });
+
+  await wallet.start(shieldedSecretKeys, dustSecretKey);
+
+  return { wallet, shieldedSecretKeys, dustSecretKey, unshieldedKeystore };
+};
+```
+
+---
+
+## Migration Checklist
+
+### 1. Update dependencies
+
+Update all `@midnight-ntwrk` packages in `package.json` to v2.0.0 versions (see [Package Version Reference](#package-version-reference)).
+
+### 2. Update Docker images
+
+Update `standalone.yml` with new image tags (see [Docker Image Updates](#docker-image-updates)).
+
+### 3. Replace WalletFacade constructor
+
+- [ ] Replace `new WalletFacade(shielded, unshielded, dust)` with `WalletFacade.init({ configuration, shielded, unshielded, dust })`
+- [ ] Merge separate wallet configs into a single `DefaultConfiguration`
+- [ ] Import `DefaultConfiguration` from `@midnight-ntwrk/wallet-sdk-facade`
+
+### 4. Remove proving from wallet builders
+
+- [ ] Remove `.withProving()` / `.withProvingDefaults()` calls
+- [ ] Remove `provingService` from builder configs
+- [ ] Optionally pass `provingService` to `WalletFacade.init()` for custom provers
+
+### 5. Update address handling
+
+- [ ] Replace `string` receiver addresses with typed `ShieldedAddress` / `UnshieldedAddress`
+- [ ] Use `wallet.shielded.getAddress()`, `wallet.unshielded.getAddress()`, `wallet.dust.getAddress()`
+- [ ] Parse Bech32 strings via `MidnightBech32m.parse()` + `codec.decode()` where needed
+
+### 6. Fix dust wallet renames
+
+- [ ] `walletBalance()` → `balance()`
+- [ ] `dustPublicKey` → `publicKey`
+- [ ] `dustAddress` → `address`
+- [ ] `getDustPublicKey()` → `getPublicKey()`
+- [ ] `getDustAddress()` → `getAddress()`
+- [ ] `DustCoreWallet` → `CoreWallet`
+
+### 7. Update imports
+
+- [ ] `UnboundTransaction` — import from `@midnight-ntwrk/wallet-sdk-capabilities/proving`
+- [ ] `SyncProgress` — import from `@midnight-ntwrk/wallet-sdk-abstractions`
+
+### 8. Handle new transaction reversion
+
+- [ ] Remove manual revert logic for proving/submission failures (facade handles it)
+- [ ] Access `state.pending` for pending transaction monitoring if needed
+
+### 9. Test
+
+- [ ] Verify wallet sync
+- [ ] Verify transfer transactions (shielded + unshielded)
+- [ ] Verify dust registration
+- [ ] Verify transaction finalization and submission
+- [ ] Verify graceful handling of failed transactions (auto-revert)
+
+---
+
+## Known Issues
+
+### Pending coins not cleared after failed shielded transaction
+
+When submission fails for a shielded transaction, pending coins may not be automatically released in some edge cases.
+
+**Workaround**: Restart the wallet or re-sync to clear stale pending state.
+
+### No transaction history for shielded/dust wallets
+
+Shielded and dust wallets do not track transaction history. Only the unshielded wallet maintains transaction records. Calling the transaction history getter on the shielded wallet will throw a "not yet implemented" error.

--- a/README.md
+++ b/README.md
@@ -41,14 +41,24 @@ npm start
 
 This single command will:
 
-1. **Pull** the latest Docker images for the Midnight node, indexer, and proof server
-2. **Start** all three containers with health checks
-3. **Initialize** the genesis master wallet (seed `0x00...001`) which holds all minted NIGHT tokens
-4. **Register DUST** for the master wallet (required to pay transaction fees)
-5. **Display** the master wallet balance
-6. **Present an interactive menu** for funding test accounts
+1. **Detect** if a local Midnight network is already running
+   - If running: prompt to **reuse** it or **restart** with fresh images
+   - If not running: **pull** Docker images and **start** all containers
+2. **Initialize** the genesis master wallet (seed `0x00...001`) which holds all minted NIGHT tokens
+3. **Register DUST** for the master wallet (required to pay transaction fees)
+4. **Display** the master wallet balance
+5. **Present an interactive menu** for funding test accounts
 
-Once running, you'll see:
+If a network is already running, you'll first see:
+
+```
+A local dev network is already running:
+  [1] Use the existing network
+  [2] Stop containers, pull latest images, and restart
+>
+```
+
+Then the main menu:
 
 ```
 Choose an option:
@@ -59,7 +69,7 @@ Choose an option:
 >
 ```
 
-When you select `[4] Exit` or press `Ctrl+C`, the tool gracefully shuts down all wallets and stops the Docker containers.
+When you select `[4] Exit` or press `Ctrl+C`, the tool gracefully shuts down all wallets. Docker containers are only stopped if they were started by this session (reusing an existing network leaves containers running).
 
 ---
 
@@ -82,9 +92,23 @@ All services use the `undeployed` network ID with the `dev` node preset.
 
 | Service | Image | Version |
 |---|---|---|
-| Node | `midnightntwrk/midnight-node` | `0.20.0` |
-| Indexer | `midnightntwrk/indexer-standalone` | `3.0.0` |
+| Node | `midnightntwrk/midnight-node` | `0.21.0` |
+| Indexer | `midnightntwrk/indexer-standalone` | `3.1.0` |
 | Proof Server | `midnightntwrk/proof-server` | `7.0.0` |
+
+### Wallet SDK Compatibility Matrix
+
+| Package | Version |
+|---|---|
+| `@midnight-ntwrk/wallet-sdk-facade` | 2.0.0 |
+| `@midnight-ntwrk/wallet-sdk-abstractions` | 2.0.0 |
+| `@midnight-ntwrk/wallet-sdk-shielded` | 2.0.0 |
+| `@midnight-ntwrk/wallet-sdk-dust-wallet` | 2.0.0 |
+| `@midnight-ntwrk/wallet-sdk-unshielded-wallet` | 2.0.0 |
+| `@midnight-ntwrk/wallet-sdk-address-format` | 3.0.1 |
+| `@midnight-ntwrk/wallet-sdk-hd` | 3.0.1 |
+| `@midnight-ntwrk/ledger-v7` | 7.0.2 |
+| `@midnight-ntwrk/midnight-js-network-id` | 3.1.0 |
 
 ---
 
@@ -278,14 +302,18 @@ Copy `.env.example` to `.env` and configure as needed:
 ### Startup Sequence
 
 ```
-1. docker compose up
-   ├── midnight-node starts (waits for health: /health endpoint)
-   ├── midnight-indexer starts (waits for: "starting indexing" log)
-   └── midnight-proof-server starts (waits for: "Actix runtime found" log)
+1. Network detection
+   ├── Check if midnight-node, midnight-indexer, midnight-proof-server are running
+   ├── If running → prompt: reuse existing or restart fresh
+   └── If not running → docker compose up
+       ├── midnight-node starts (waits for health: /health endpoint)
+       ├── midnight-indexer starts (waits for: "starting indexing" log)
+       └── midnight-proof-server starts (waits for: "Actix runtime found" log)
 
-2. Master wallet initialization
+2. Master wallet initialization (WalletFacade.init)
    ├── Derive HD wallet from genesis seed (0x00...001)
-   ├── Create shielded, unshielded, and dust wallets
+   ├── Create unified DefaultConfiguration
+   ├── Initialize WalletFacade with shielded, unshielded, and dust builders
    ├── Start wallet facade and wait for sync
    └── Display genesis NIGHT balance
 
@@ -298,7 +326,7 @@ Copy `.env.example` to `.env` and configure as needed:
 
 5. Cleanup on exit
    ├── Close all wallet connections
-   └── docker compose down
+   └── docker compose down (only if network was started by this session)
 ```
 
 ### Key Concepts

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,15 @@
       "name": "midnight-local-network",
       "version": "0.1.0",
       "dependencies": {
-        "@midnight-ntwrk/ledger-v7": "7.0.0",
+        "@midnight-ntwrk/ledger-v7": "7.0.2",
         "@midnight-ntwrk/midnight-js-network-id": "3.1.0",
-        "@midnight-ntwrk/wallet-sdk-abstractions": "1.0.0",
-        "@midnight-ntwrk/wallet-sdk-address-format": "3.0.0",
-        "@midnight-ntwrk/wallet-sdk-dust-wallet": "1.0.0",
-        "@midnight-ntwrk/wallet-sdk-facade": "1.0.0",
-        "@midnight-ntwrk/wallet-sdk-hd": "3.0.0",
-        "@midnight-ntwrk/wallet-sdk-shielded": "1.0.0",
-        "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "1.0.0",
+        "@midnight-ntwrk/wallet-sdk-abstractions": "2.0.0",
+        "@midnight-ntwrk/wallet-sdk-address-format": "3.0.1",
+        "@midnight-ntwrk/wallet-sdk-dust-wallet": "2.0.0",
+        "@midnight-ntwrk/wallet-sdk-facade": "2.0.0",
+        "@midnight-ntwrk/wallet-sdk-hd": "3.0.1",
+        "@midnight-ntwrk/wallet-sdk-shielded": "2.0.0",
+        "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "2.0.0",
         "@scure/bip39": "^2.0.1",
         "dotenv": "^17.2.3",
         "pino": "^10.1.0",
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@effect/platform": {
-      "version": "0.90.10",
-      "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.90.10.tgz",
-      "integrity": "sha512-QhDPgCaLfIMQKOCoCPQvRUS+Y34iYJ07jdZ/CBAvYFvg/iUBebsmFuHL63RCD/YZH9BuK/kqqLYAA3M0fmUEgg==",
+      "version": "0.94.5",
+      "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.94.5.tgz",
+      "integrity": "sha512-z05APUiDDPbodhTkH/RJqOLoCU11bU2IZLfcwLFrld03+ob1VeqRnELQlmueLIYm6NZifHAtjl32V+GRt34y4A==",
       "license": "MIT",
       "dependencies": {
         "find-my-way-ts": "^0.1.6",
@@ -65,7 +65,7 @@
         "multipasta": "^0.2.7"
       },
       "peerDependencies": {
-        "effect": "^3.17.13"
+        "effect": "^3.19.17"
       }
     },
     "node_modules/@graphql-typed-document-node/core": {
@@ -191,9 +191,9 @@
       }
     },
     "node_modules/@midnight-ntwrk/ledger-v7": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/ledger-v7/-/ledger-v7-7.0.0.tgz",
-      "integrity": "sha512-9rch1jU0T9pwt64nR79PhrnrT/mwrS1EKGh4J3q0UT0sBqmylw0c2eREdd26Mq9Kf4FOfAdKxJUaV+IlNh5yUA=="
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/ledger-v7/-/ledger-v7-7.0.2.tgz",
+      "integrity": "sha512-8ICrpYxLXj9vCskCrP6Rxh8z7H4WkemYLj7BBtVyNxLZM5EDIxdVMo7+wZXtEUwPUcxPEFFBw3/5YddSE1zoOQ=="
     },
     "node_modules/@midnight-ntwrk/midnight-js-network-id": {
       "version": "3.1.0",
@@ -202,212 +202,190 @@
       "license": "Apache-2.0"
     },
     "node_modules/@midnight-ntwrk/wallet-sdk-abstractions": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-abstractions/-/wallet-sdk-abstractions-1.0.0.tgz",
-      "integrity": "sha512-kJb3I1jYCuI3y1nvCixPlw4QwThrUnv0RT/eHUFB36Zir49qW4qIa5a7g2vDLXW2PL2tbh8m5xoTDFQirThI9w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-abstractions/-/wallet-sdk-abstractions-2.0.0.tgz",
+      "integrity": "sha512-urmdK+lpw/gmX3mKjN3p9rVUn6Ba3TyHVEYN5oAXc0na4NkHsvvhgxcn9t4Oh9FYoYWuUA0xDiiLJsAkO05b/A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "effect": "^3.19.14"
+        "effect": "^3.19.19"
       }
     },
     "node_modules/@midnight-ntwrk/wallet-sdk-address-format": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-address-format/-/wallet-sdk-address-format-3.0.0.tgz",
-      "integrity": "sha512-h46Dq+vY6Ymbll58tZyHJGd0dJmNE/Ae2PJKslP3Mb8rpDG0HhiGcqYkGvRxH6Tc/MqM0yABgAcQetjcvIe8qA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-address-format/-/wallet-sdk-address-format-3.0.1.tgz",
+      "integrity": "sha512-/ptjkArU6jqUzUMlXl7UQSvSBpIoVKUa8NtAftwueji1bEb9EceErKSASh7l4ir3RAlGsRtyDIhDETvYDpXZ3Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@midnight-ntwrk/ledger-v7": "7.0.0",
-        "@scure/base": "^1.2.6",
+        "@midnight-ntwrk/ledger-v7": "^7.0.2",
+        "@scure/base": "^2.0.0",
         "@subsquid/scale-codec": "^4.0.1"
       }
     },
     "node_modules/@midnight-ntwrk/wallet-sdk-capabilities": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-capabilities/-/wallet-sdk-capabilities-3.0.0.tgz",
-      "integrity": "sha512-iVNIb7TTzEFdipHu37ppSSl1CZ4vXcJz5kwWxI3szwMJhPrRJp0ZTiD//mA4PdXNNO0CrarPo3hn5QOxCZir5Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-capabilities/-/wallet-sdk-capabilities-3.1.0.tgz",
+      "integrity": "sha512-HAts0b8nZEh6hWnmRZRf08/dK5UWOzIEX1bMGFt78ykp8PuyyFy49V9uY5oMF7ed72sceTaRFJzYpILoa7qDVw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@midnight-ntwrk/wallet-sdk-address-format": "3.0.0",
-        "@midnight-ntwrk/wallet-sdk-hd": "3.0.0",
-        "effect": "^3.19.14"
+        "@midnight-ntwrk/ledger-v7": "^7.0.2",
+        "@midnight-ntwrk/wallet-sdk-abstractions": "^2.0.0",
+        "@midnight-ntwrk/wallet-sdk-indexer-client": "^1.1.0",
+        "@midnight-ntwrk/wallet-sdk-node-client": "^1.0.1",
+        "@midnight-ntwrk/wallet-sdk-prover-client": "^1.1.0",
+        "@midnight-ntwrk/wallet-sdk-utilities": "^1.0.1",
+        "@midnight-ntwrk/zkir-v2": "^2.1.0",
+        "effect": "^3.19.19",
+        "rxjs": "^7.8.2"
       }
     },
     "node_modules/@midnight-ntwrk/wallet-sdk-dust-wallet": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-dust-wallet/-/wallet-sdk-dust-wallet-1.0.0.tgz",
-      "integrity": "sha512-+juz3u8HEEcfB5wV20emarsu3HmFP5qAu5bHpTjtG9XMtVryZihe9d1teCwUWfIiBZDs+Rg1nVwLbPesvVYbgQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-dust-wallet/-/wallet-sdk-dust-wallet-2.0.0.tgz",
+      "integrity": "sha512-/D7SvVdWaYxN2Gowog9+vDqb2HYzruxB+O33rk/NY9O+3FOYHF1H2RNS1ZrqJlvyLo7uj4JFYG8g0R1PRadSxw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@midnight-ntwrk/ledger-v7": "7.0.0",
-        "@midnight-ntwrk/wallet-sdk-abstractions": "1.0.0",
-        "@midnight-ntwrk/wallet-sdk-address-format": "3.0.0",
-        "@midnight-ntwrk/wallet-sdk-capabilities": "3.0.0",
-        "@midnight-ntwrk/wallet-sdk-hd": "3.0.0",
-        "@midnight-ntwrk/wallet-sdk-indexer-client": "1.0.0",
-        "@midnight-ntwrk/wallet-sdk-node-client": "1.0.0",
-        "@midnight-ntwrk/wallet-sdk-prover-client": "1.0.0",
-        "@midnight-ntwrk/wallet-sdk-shielded": "1.0.0",
-        "@midnight-ntwrk/wallet-sdk-utilities": "1.0.0",
-        "effect": "^3.19.14",
-        "rxjs": "^7.5"
+        "@midnight-ntwrk/ledger-v7": "^7.0.2",
+        "@midnight-ntwrk/wallet-sdk-abstractions": "2.0.0",
+        "@midnight-ntwrk/wallet-sdk-address-format": "3.0.1",
+        "@midnight-ntwrk/wallet-sdk-capabilities": "3.1.0",
+        "@midnight-ntwrk/wallet-sdk-indexer-client": "1.1.0",
+        "@midnight-ntwrk/wallet-sdk-runtime": "1.0.1",
+        "@midnight-ntwrk/wallet-sdk-utilities": "1.0.1",
+        "effect": "^3.19.19",
+        "rxjs": "^7.8.2"
       }
     },
     "node_modules/@midnight-ntwrk/wallet-sdk-facade": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-facade/-/wallet-sdk-facade-1.0.0.tgz",
-      "integrity": "sha512-B5wxfEdIYIGuWy4nRZ7Mk1STjoSLu1XVScwhA/4fiiGM5ugTBA/6QQzqkpk+datNQ9NwLsSZOsl93m69Cx0ZYQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-facade/-/wallet-sdk-facade-2.0.0.tgz",
+      "integrity": "sha512-iPZEG2ayhmRbWFCcw/QposGQwMYs81P3J/ipzLLuw0BJiSrzBc3cX8Lg+UmrfoNNEzIpY916Tq8nLgRpQ2zV3A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@midnight-ntwrk/ledger-v7": "7.0.0",
-        "@midnight-ntwrk/wallet-sdk-abstractions": "1.0.0",
-        "@midnight-ntwrk/wallet-sdk-address-format": "3.0.0",
-        "@midnight-ntwrk/wallet-sdk-dust-wallet": "1.0.0",
-        "@midnight-ntwrk/wallet-sdk-hd": "3.0.0",
-        "@midnight-ntwrk/wallet-sdk-shielded": "1.0.0",
-        "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "1.0.0",
-        "rxjs": "^7.5"
+        "@midnight-ntwrk/ledger-v7": "^7.0.2",
+        "@midnight-ntwrk/wallet-sdk-address-format": "^3.0.1",
+        "@midnight-ntwrk/wallet-sdk-capabilities": "^3.1.0",
+        "@midnight-ntwrk/wallet-sdk-dust-wallet": "^2.0.0",
+        "@midnight-ntwrk/wallet-sdk-shielded": "^2.0.0",
+        "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "^2.0.0",
+        "rxjs": "^7.8.2"
       }
     },
     "node_modules/@midnight-ntwrk/wallet-sdk-hd": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-hd/-/wallet-sdk-hd-3.0.0.tgz",
-      "integrity": "sha512-HP2ljS4+611rN5S1sO8JqpggVdtl8hviKBowOowcZ8nbnll6smXXn/8FBD2W5MhNIp3aqd0fiBuVLe1si7yLYQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-hd/-/wallet-sdk-hd-3.0.1.tgz",
+      "integrity": "sha512-N2s4fPQofIHL9r+Wt4qvWGHQoBFjIO7pZhOALfKuAZEaDUZdwbwrw8NnfA4vKklfhEZ5wWrIBUeFgKFI9qD6hw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@scure/base": "^1.1.9",
-        "@scure/bip32": "^1.6.2",
-        "@scure/bip39": "^1.5.4"
-      }
-    },
-    "node_modules/@midnight-ntwrk/wallet-sdk-hd/node_modules/@scure/bip39": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
-      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "~1.8.0",
-        "@scure/base": "~1.2.5"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
+        "@scure/bip32": "^2.0.1",
+        "@scure/bip39": "^2.0.1"
       }
     },
     "node_modules/@midnight-ntwrk/wallet-sdk-indexer-client": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-indexer-client/-/wallet-sdk-indexer-client-1.0.0.tgz",
-      "integrity": "sha512-3ODr+Cmn/MC4t32d0/kRDA6S21RLf0ZFjDFtWMkof9tpfBANhp+HKT132Z8AlajxykJ7ZQZJLhPfWAh7pfDiag==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-indexer-client/-/wallet-sdk-indexer-client-1.1.0.tgz",
+      "integrity": "sha512-ohvgqrjd33ALIqZIxYb2xsot0TlMoCY/IcWJ7/o70YNIPTxSlwEjuxoJR+CsjA25ajMDzpi87gm0ARdgigSh0Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@effect/platform": "^0.90.0",
         "@graphql-typed-document-node/core": "^3.2.0",
-        "@midnight-ntwrk/wallet-sdk-abstractions": "1.0.0",
-        "@midnight-ntwrk/wallet-sdk-utilities": "1.0.0",
-        "effect": "^3.19.14",
-        "graphql": "^16.11.0",
+        "@midnight-ntwrk/wallet-sdk-utilities": "1.0.1",
+        "effect": "^3.19.19",
+        "graphql": "^16.13.0",
         "graphql-http": "^1.22.4",
-        "graphql-ws": "^6.0.5"
+        "graphql-ws": "^6.0.7"
       }
     },
     "node_modules/@midnight-ntwrk/wallet-sdk-node-client": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-node-client/-/wallet-sdk-node-client-1.0.0.tgz",
-      "integrity": "sha512-YCFZIOsQlvvG1sZdq+HzEzHniM9je2JPFaiedYpX7jZang0RdUijBrNsPxEjd8yn78wZROZiZ/GMViBXHpOQGQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-node-client/-/wallet-sdk-node-client-1.0.1.tgz",
+      "integrity": "sha512-lAJHZ0nIwrOyc9AB6XDuQCtKHXDt3mPfYorj0PzQuBQHfTwMYrpFWARjFViIEIvJfxrNGii221CwSScjznJJAA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@polkadot/api": "^16.3.1",
-        "@polkadot/api-augment": "^16.3.1",
-        "@polkadot/api-base": "^16.3.1",
-        "@polkadot/rpc-augment": "^16.3.1",
-        "@polkadot/rpc-core": "^16.3.1",
-        "@polkadot/types": "^16.3.1",
-        "@polkadot/types-augment": "^16.3.1",
-        "@polkadot/types-codec": "^16.3.1",
-        "@polkadot/types-known": "^16.3.1",
-        "@polkadot/types-support": "^16.3.1",
+        "@midnight-ntwrk/wallet-sdk-abstractions": "2.0.0",
+        "@midnight-ntwrk/wallet-sdk-utilities": "1.0.1",
+        "@polkadot/api": "^16.5.4",
+        "@polkadot/types": "^16.5.4",
+        "@polkadot/util": "^14.0.1",
         "@types/bn.js": "^5.2.0",
-        "bn.js": "^5.2.2",
-        "effect": "^3.19.14",
-        "rxjs": "^7.5",
-        "testcontainers": "^11.10.0"
+        "bn.js": "^5.2.3",
+        "effect": "^3.19.19"
       }
     },
     "node_modules/@midnight-ntwrk/wallet-sdk-prover-client": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-prover-client/-/wallet-sdk-prover-client-1.0.0.tgz",
-      "integrity": "sha512-dHZkrjCd3CitxmInoyjfyUFGGB2bxjfFV/DIspSd7pE4OKWvgheb4+1z8FKdkFOBdO4kjpuY+xuL5LWZhTfjFA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-prover-client/-/wallet-sdk-prover-client-1.1.0.tgz",
+      "integrity": "sha512-0/eAudqlylztJzsCyJ2kCpRYhThPRl1vvK2zgj8X16NWxFGebGuQIJGJElZtkeImBA4kDXvmk46rrsAMVTjXZw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@effect/platform": "^0.90.0",
-        "@midnight-ntwrk/ledger-v7": "7.0.0",
-        "@midnight-ntwrk/wallet-sdk-abstractions": "1.0.0",
-        "@midnight-ntwrk/wallet-sdk-utilities": "1.0.0",
-        "effect": "^3.19.14"
+        "@effect/platform": "^0.94.5",
+        "@midnight-ntwrk/ledger-v7": "^7.0.2",
+        "@midnight-ntwrk/wallet-sdk-utilities": "1.0.1",
+        "@midnight-ntwrk/zkir-v2": "2.1.0",
+        "effect": "^3.19.19",
+        "web-worker": "^1.5.0"
       }
     },
     "node_modules/@midnight-ntwrk/wallet-sdk-runtime": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-runtime/-/wallet-sdk-runtime-1.0.0.tgz",
-      "integrity": "sha512-bwazJ9h2LmgN/Su6GFzf1EAxUmP89m9HLXS4EkRgcc9n13B23ABIzPxSMSQAbn7YlM9U5CfSuiJKNAuojtARdg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-runtime/-/wallet-sdk-runtime-1.0.1.tgz",
+      "integrity": "sha512-jUyXHTWBYcb4id0706LeMLoCOx1wdprmy2B6qXjbqPUmKnKRtgDt58xhg7EApZlTewDUAyOMHJO1srlqzQTz2A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@midnight-ntwrk/wallet-sdk-abstractions": "1.0.0",
-        "@midnight-ntwrk/wallet-sdk-utilities": "1.0.0",
-        "effect": "^3.19.14",
-        "rxjs": "^7.5"
+        "@midnight-ntwrk/wallet-sdk-abstractions": "2.0.0",
+        "@midnight-ntwrk/wallet-sdk-utilities": "1.0.1",
+        "effect": "^3.19.19",
+        "rxjs": "^7.8.2"
       }
     },
     "node_modules/@midnight-ntwrk/wallet-sdk-shielded": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-shielded/-/wallet-sdk-shielded-1.0.0.tgz",
-      "integrity": "sha512-gMQr4CBMYqOqzfniNUBYASoieRxWgAc3558+gN8HY2z9o/Aya9IyI3kwvBOQmsSVt2gUsWs4QEkLQxckdfBGnA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-shielded/-/wallet-sdk-shielded-2.0.0.tgz",
+      "integrity": "sha512-AKu3BjNe4PtlJzJCzEIIvwPWlzO4xzu1XzaenzbPAhPC5f3hN+2itNs6xXSukVwIwiywepJ10NpORgO6vL82pg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@midnight-ntwrk/ledger-v7": "7.0.0",
-        "@midnight-ntwrk/wallet-sdk-abstractions": "1.0.0",
-        "@midnight-ntwrk/wallet-sdk-address-format": "3.0.0",
-        "@midnight-ntwrk/wallet-sdk-capabilities": "3.0.0",
-        "@midnight-ntwrk/wallet-sdk-indexer-client": "1.0.0",
-        "@midnight-ntwrk/wallet-sdk-node-client": "1.0.0",
-        "@midnight-ntwrk/wallet-sdk-prover-client": "1.0.0",
-        "@midnight-ntwrk/wallet-sdk-runtime": "1.0.0",
-        "@midnight-ntwrk/wallet-sdk-utilities": "1.0.0",
-        "@scure/base": "^1.1.9",
-        "effect": "^3.19.14",
-        "isomorphic-ws": "^5.0.0",
-        "node-fetch": "3.3.2",
-        "rxjs": "^7.5",
-        "scale-ts": "^1.1.0",
-        "ws": "^8.18.3"
+        "@midnight-ntwrk/ledger-v7": "^7.0.2",
+        "@midnight-ntwrk/wallet-sdk-abstractions": "2.0.0",
+        "@midnight-ntwrk/wallet-sdk-address-format": "3.0.1",
+        "@midnight-ntwrk/wallet-sdk-capabilities": "3.1.0",
+        "@midnight-ntwrk/wallet-sdk-indexer-client": "1.1.0",
+        "@midnight-ntwrk/wallet-sdk-runtime": "1.0.1",
+        "@midnight-ntwrk/wallet-sdk-utilities": "1.0.1",
+        "effect": "^3.19.19",
+        "rxjs": "^7.8.2"
       }
     },
     "node_modules/@midnight-ntwrk/wallet-sdk-unshielded-wallet": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-unshielded-wallet/-/wallet-sdk-unshielded-wallet-1.0.0.tgz",
-      "integrity": "sha512-2kulO8EtKNXfkq6xUS72tYyhMvxdbvgCUBiewx4ay7uqwwe6nR1iiPYJqV5PAV1scGyEwgE0m+sf8ZqyHrge/A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-unshielded-wallet/-/wallet-sdk-unshielded-wallet-2.0.0.tgz",
+      "integrity": "sha512-1QQPYjM4Qx6mnugs0dzDP0TaEzVX3o40V5iID78TvTCPfuEC1lOJXeSJ7Evm2T+7/lvFGbvc+HPNiM28v1M6tg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@midnight-ntwrk/ledger-v7": "7.0.0",
-        "@midnight-ntwrk/wallet-sdk-abstractions": "1.0.0",
-        "@midnight-ntwrk/wallet-sdk-address-format": "3.0.0",
-        "@midnight-ntwrk/wallet-sdk-capabilities": "3.0.0",
-        "@midnight-ntwrk/wallet-sdk-hd": "3.0.0",
-        "@midnight-ntwrk/wallet-sdk-indexer-client": "1.0.0",
-        "@midnight-ntwrk/wallet-sdk-utilities": "1.0.0",
-        "effect": "^3.19.14",
-        "rxjs": "^7.5"
+        "@midnight-ntwrk/ledger-v7": "^7.0.2",
+        "@midnight-ntwrk/wallet-sdk-abstractions": "2.0.0",
+        "@midnight-ntwrk/wallet-sdk-address-format": "3.0.1",
+        "@midnight-ntwrk/wallet-sdk-capabilities": "3.1.0",
+        "@midnight-ntwrk/wallet-sdk-indexer-client": "1.1.0",
+        "@midnight-ntwrk/wallet-sdk-runtime": "1.0.1",
+        "@midnight-ntwrk/wallet-sdk-utilities": "1.0.1",
+        "effect": "^3.19.19",
+        "rxjs": "^7.8.2"
       }
     },
     "node_modules/@midnight-ntwrk/wallet-sdk-utilities": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-utilities/-/wallet-sdk-utilities-1.0.0.tgz",
-      "integrity": "sha512-lL7D/F9TvWVYXJMBUNkhsKi8gR3VWr5IB3f3ylJkGrhhJhQ0nUv0IBDR9omiKtAmZKg55cL+vYsZZqviY380ew==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/wallet-sdk-utilities/-/wallet-sdk-utilities-1.0.1.tgz",
+      "integrity": "sha512-dZBJTm1xxKyOrL4RbAaTeIVXXiLgwJ/e7iQ6W7k6rjuSzaZ/JIbOFRenk/P9ZFcq7b0tpUJvlGmTB6mvggh7wg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "effect": "^3.19.14",
-        "portfinder": "^1.0.37",
-        "rxjs": "^7.5",
-        "testcontainers": "^11.10.0"
+        "effect": "^3.19.19",
+        "portfinder": "^1.0.38",
+        "rxjs": "^7.8.2",
+        "testcontainers": "^11.12.0"
       }
+    },
+    "node_modules/@midnight-ntwrk/zkir-v2": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@midnight-ntwrk/zkir-v2/-/zkir-v2-2.1.0.tgz",
+      "integrity": "sha512-UDMujjzCt0SA89uqOFWUL4LZTkxVAS8JjvOaYMAgxlSrWfN7m5th1R1qGlpDJuSH39rbWt6WwtuK3k08Mta6LA=="
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
       "version": "3.0.3",
@@ -582,6 +560,16 @@
         "@polkadot-api/utils": "0.1.0",
         "@scure/base": "^1.1.1",
         "scale-ts": "^1.6.0"
+      }
+    },
+    "node_modules/@polkadot-api/substrate-bindings/node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@polkadot-api/substrate-client": {
@@ -911,6 +899,15 @@
         "@polkadot/util": "14.0.1"
       }
     },
+    "node_modules/@polkadot/util-crypto/node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@polkadot/wasm-bridge": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/@polkadot/wasm-bridge/-/wasm-bridge-7.5.4.tgz",
@@ -1176,23 +1173,50 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@scure/base": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
-      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
+      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip32": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
-      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-2.0.1.tgz",
+      "integrity": "sha512-4Md1NI5BzoVP+bhyJaY3K6yMesEFzNS1sE/cP+9nuvE7p/b0kx9XbpDHHFl8dHtufcbdHRUUQdRqLIPHN/s7yA==",
       "license": "MIT",
       "dependencies": {
-        "@noble/curves": "~1.9.0",
-        "@noble/hashes": "~1.8.0",
-        "@scure/base": "~1.2.5"
+        "@noble/curves": "2.0.1",
+        "@noble/hashes": "2.0.1",
+        "@scure/base": "2.0.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/curves": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.0.1.tgz",
+      "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1219,15 +1243,6 @@
       "engines": {
         "node": ">= 20.19.0"
       },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip39/node_modules/@scure/base": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
-      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
-      "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -2428,9 +2443,9 @@
       "license": "ISC"
     },
     "node_modules/graphql": {
-      "version": "16.13.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.0.tgz",
-      "integrity": "sha512-uSisMYERbaB9bkA9M4/4dnqyktaEkf1kMHNKq/7DHyxVeWqHQ2mBmVqm5u6/FVHwF3iCNalKcg82Zfl+tffWoA==",
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.1.tgz",
+      "integrity": "sha512-gGgrVCoDKlIZ8fIqXBBb0pPKqDgki0Z/FSKNiQzSGj2uEYHr1tq5wmBegGwJx6QB5S5cM0khSBpi/JFHMCvsmQ==",
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -2541,15 +2556,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
-    },
-    "node_modules/isomorphic-ws": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
-      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "ws": "*"
-      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -3223,7 +3229,8 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/scale-ts/-/scale-ts-1.6.1.tgz",
       "integrity": "sha512-PBMc2AWc6wSEqJYBDPcyCLUj9/tMKnLX70jLOSndMtcUoLQucP/DM0vnQo1wJAYjTrQiq8iG9rD0q6wFzgjH7g==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/secure-json-parse": {
       "version": "4.1.0",
@@ -3680,6 +3687,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/web-worker": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+      "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+      "license": "Apache-2.0"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -8,18 +8,18 @@
   },
   "scripts": {
     "clean": "docker rm -f midnight-node midnight-indexer midnight-proof-server 2>/dev/null; docker compose -f standalone.yml down --remove-orphans 2>/dev/null; true",
-    "start": "npm run clean && docker compose -f standalone.yml pull && node --experimental-specifier-resolution=node --loader ts-node/esm src/index.ts"
+    "start": "node --experimental-specifier-resolution=node --loader ts-node/esm src/index.ts"
   },
   "dependencies": {
-    "@midnight-ntwrk/ledger-v7": "7.0.0",
+    "@midnight-ntwrk/ledger-v7": "7.0.2",
     "@midnight-ntwrk/midnight-js-network-id": "3.1.0",
-    "@midnight-ntwrk/wallet-sdk-abstractions": "1.0.0",
-    "@midnight-ntwrk/wallet-sdk-address-format": "3.0.0",
-    "@midnight-ntwrk/wallet-sdk-dust-wallet": "1.0.0",
-    "@midnight-ntwrk/wallet-sdk-facade": "1.0.0",
-    "@midnight-ntwrk/wallet-sdk-hd": "3.0.0",
-    "@midnight-ntwrk/wallet-sdk-shielded": "1.0.0",
-    "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "1.0.0",
+    "@midnight-ntwrk/wallet-sdk-abstractions": "2.0.0",
+    "@midnight-ntwrk/wallet-sdk-address-format": "3.0.1",
+    "@midnight-ntwrk/wallet-sdk-dust-wallet": "2.0.0",
+    "@midnight-ntwrk/wallet-sdk-facade": "2.0.0",
+    "@midnight-ntwrk/wallet-sdk-hd": "3.0.1",
+    "@midnight-ntwrk/wallet-sdk-shielded": "2.0.0",
+    "@midnight-ntwrk/wallet-sdk-unshielded-wallet": "2.0.0",
     "@scure/bip39": "^2.0.1",
     "dotenv": "^17.2.3",
     "pino": "^10.1.0",
@@ -35,7 +35,7 @@
     "typescript": "^5.9.3"
   },
   "resolutions": {
-    "@midnight-ntwrk/ledger-v7": "7.0.0",
+    "@midnight-ntwrk/ledger-v7": "7.0.2",
     "@midnight-ntwrk/midnight-js-network-id": "3.1.0"
   }
 }

--- a/src/funding.ts
+++ b/src/funding.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs/promises';
 import * as ledger from '@midnight-ntwrk/ledger-v7';
+import { MidnightBech32m, UnshieldedAddress } from '@midnight-ntwrk/wallet-sdk-address-format';
 import { type Logger } from 'pino';
 import {
   type WalletContext,
@@ -45,7 +46,7 @@ interface AccountsFile {
  */
 async function transferNight(
   masterWallet: WalletContext,
-  receiverAddress: string,
+  receiverAddress: UnshieldedAddress,
   amount: bigint,
 ): Promise<string> {
   const ttl = new Date(Date.now() + 30 * 60 * 1000);
@@ -102,11 +103,11 @@ export async function fundFromConfigFile(
     const account = accountsFile.accounts[i];
     logger.info(`\n--- Account ${i + 1}/${accountsFile.accounts.length}: ${account.name} ---`);
 
-    // Derive wallet from mnemonic to get Bech32 address
+    // Derive wallet from mnemonic to get address
     const seed = await mnemonicToSeed(account.mnemonic);
     const recipientWallet = await initWalletWithSeed(seed, config);
-    const recipientAddress = recipientWallet.unshieldedKeystore.getBech32Address().asString();
-    logger.info(`Recipient address: ${recipientAddress}`);
+    const recipientAddress = await recipientWallet.wallet.unshielded.getAddress();
+    logger.info(`Recipient address: ${recipientWallet.unshieldedKeystore.getBech32Address().asString()}`);
 
     // Transfer NIGHT from master
     logger.info(`Transferring ${NIGHT_AMOUNT} NIGHT to ${account.name}...`);
@@ -151,34 +152,38 @@ export async function fundFromConfigFile(
 export async function fundFromPublicKeys(
   masterWallet: WalletContext,
   pubKeysInput: string,
+  config: Config,
 ): Promise<FundedAccount[]> {
-  const addresses = pubKeysInput
+  const addressStrings = pubKeysInput
     .split(',')
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
 
-  if (addresses.length === 0) {
+  if (addressStrings.length === 0) {
     throw new Error('No addresses provided');
   }
 
-  if (addresses.length > MAX_ACCOUNTS) {
-    throw new Error(`Too many addresses: max ${MAX_ACCOUNTS}, got ${addresses.length}`);
+  if (addressStrings.length > MAX_ACCOUNTS) {
+    throw new Error(`Too many addresses: max ${MAX_ACCOUNTS}, got ${addressStrings.length}`);
   }
 
-  logger.info(`Funding ${addresses.length} addresses with NIGHT only...`);
+  logger.info(`Funding ${addressStrings.length} addresses with NIGHT only...`);
   const funded: FundedAccount[] = [];
 
-  for (let i = 0; i < addresses.length; i++) {
-    const address = addresses[i];
-    logger.info(`\n--- Address ${i + 1}/${addresses.length}: ${address} ---`);
+  for (let i = 0; i < addressStrings.length; i++) {
+    const addressStr = addressStrings[i];
+    logger.info(`\n--- Address ${i + 1}/${addressStrings.length}: ${addressStr} ---`);
+
+    const parsed = MidnightBech32m.parse(addressStr);
+    const unshieldedAddress = UnshieldedAddress.codec.decode(config.networkId as any, parsed);
 
     logger.info(`Transferring ${NIGHT_AMOUNT} NIGHT...`);
-    const txId = await transferNight(masterWallet, address, NIGHT_AMOUNT);
+    const txId = await transferNight(masterWallet, unshieldedAddress, NIGHT_AMOUNT);
     logger.info(`Transfer submitted: ${txId}`);
 
     funded.push({
-      name: address,
-      unshieldedAddr: address,
+      name: addressStr,
+      unshieldedAddr: addressStr,
       shieldedAddr: 'N/A',
       dustAddr: 'N/A',
       nightBalance: NIGHT_AMOUNT,
@@ -186,6 +191,6 @@ export async function fundFromPublicKeys(
     });
   }
 
-  logger.info(`\nAll ${addresses.length} addresses funded with NIGHT (DUST not registered - recipients must do it themselves).`);
+  logger.info(`\nAll ${addressStrings.length} addresses funded with NIGHT (DUST not registered - recipients must do it themselves).`);
   return funded;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { type StartedDockerComposeEnvironment } from 'testcontainers';
 import { type Logger } from 'pino';
 import { StandaloneConfig } from './config.js';
 import { createLogger } from './logger.js';
-import { startNetwork, stopNetwork } from './network.js';
+import { isNetworkRunning, startNetwork, freshStart, stopNetwork } from './network.js';
 import {
   type WalletContext,
   setLogger as setWalletLogger,
@@ -72,7 +72,7 @@ async function mainMenu(
         }
         case '2': {
           const pubKeys = await rli.question('Enter Bech32 addresses (comma-separated): ');
-          const accounts = await fundFromPublicKeys(masterWallet, pubKeys);
+          const accounts = await fundFromPublicKeys(masterWallet, pubKeys, config);
           fundedAccounts.push(...accounts);
           break;
         }
@@ -111,8 +111,20 @@ async function main(): Promise<void> {
   let masterWallet: WalletContext | null = null;
 
   try {
-    // 1. Start docker compose network
-    env = await startNetwork(config, logger);
+    // 1. Detect or start docker compose network
+    if (isNetworkRunning()) {
+      logger.info('Detected a running Midnight local network.');
+      const startChoice = await rli.question(
+        '\nA local dev network is already running:\n  [1] Use the existing network\n  [2] Stop containers, pull latest images, and restart\n> ',
+      );
+      if (startChoice.trim() === '2') {
+        env = await freshStart(config, logger);
+      } else {
+        logger.info('Using existing network.');
+      }
+    } else {
+      env = await startNetwork(config, logger);
+    }
 
     // 2. Initialize master wallet from genesis seed
     logger.info('Initializing master wallet from genesis seed...');

--- a/src/network.ts
+++ b/src/network.ts
@@ -1,13 +1,55 @@
 import path from 'node:path';
+import { execSync } from 'node:child_process';
 import { DockerComposeEnvironment, Wait, type StartedDockerComposeEnvironment } from 'testcontainers';
 import { type Config } from './config.js';
 import { currentDir } from './config.js';
 import { type Logger } from 'pino';
 
+const CONTAINER_NAMES = ['midnight-node', 'midnight-indexer', 'midnight-proof-server'];
+
 export const createDockerEnv = (): DockerComposeEnvironment => {
   return new DockerComposeEnvironment(path.resolve(currentDir, '..'), 'standalone.yml')
     .withWaitStrategy('midnight-proof-server', Wait.forLogMessage('Actix runtime found; starting in Actix runtime', 1))
     .withWaitStrategy('midnight-indexer', Wait.forLogMessage(/starting indexing/, 1));
+};
+
+/**
+ * Check if the Midnight local network containers are already running.
+ */
+export const isNetworkRunning = (): boolean => {
+  try {
+    const result = execSync(
+      `docker ps --filter "status=running" --format "{{.Names}}"`,
+      { encoding: 'utf-8' },
+    );
+    const running = result.trim().split('\n').filter(Boolean);
+    return CONTAINER_NAMES.every((name) => running.includes(name));
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Stop and remove existing Midnight containers, pull fresh images, and start.
+ */
+export const freshStart = async (config: Config, logger: Logger): Promise<StartedDockerComposeEnvironment> => {
+  logger.info('Stopping existing containers...');
+  try {
+    execSync(
+      `docker rm -f ${CONTAINER_NAMES.join(' ')} 2>/dev/null; docker compose -f standalone.yml down --remove-orphans 2>/dev/null`,
+      { cwd: path.resolve(currentDir, '..'), stdio: 'ignore' },
+    );
+  } catch {
+    // ignore cleanup errors
+  }
+
+  logger.info('Pulling latest images...');
+  execSync('docker compose -f standalone.yml pull', {
+    cwd: path.resolve(currentDir, '..'),
+    stdio: 'inherit',
+  });
+
+  return startNetwork(config, logger);
 };
 
 export const startNetwork = async (config: Config, logger: Logger): Promise<StartedDockerComposeEnvironment> => {

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -1,6 +1,6 @@
 import * as ledger from '@midnight-ntwrk/ledger-v7';
 import { HDWallet, Roles } from '@midnight-ntwrk/wallet-sdk-hd';
-import { WalletFacade } from '@midnight-ntwrk/wallet-sdk-facade';
+import { type DefaultConfiguration, WalletFacade } from '@midnight-ntwrk/wallet-sdk-facade';
 import { ShieldedWallet } from '@midnight-ntwrk/wallet-sdk-shielded';
 import { DustWallet } from '@midnight-ntwrk/wallet-sdk-dust-wallet';
 import {
@@ -10,7 +10,7 @@ import {
   type UnshieldedKeystore,
   UnshieldedWallet,
 } from '@midnight-ntwrk/wallet-sdk-unshielded-wallet';
-import { DustAddress, MidnightBech32m } from '@midnight-ntwrk/wallet-sdk-address-format';
+import { DustAddress, MidnightBech32m, UnshieldedAddress } from '@midnight-ntwrk/wallet-sdk-address-format';
 import * as bip39 from '@scure/bip39';
 import { wordlist as english } from '@scure/bip39/wordlists/english.js';
 import { type Logger } from 'pino';
@@ -73,54 +73,29 @@ export const initWalletWithSeed = async (
 
   const shieldedSecretKeys = ledger.ZswapSecretKeys.fromSeed(derivationResult.keys[Roles.Zswap]);
   const dustSecretKey = ledger.DustSecretKey.fromSeed(derivationResult.keys[Roles.Dust]);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const unshieldedKeystore = createKeystore(derivationResult.keys[Roles.NightExternal], config.networkId as any);
+  const unshieldedKeystore = createKeystore(derivationResult.keys[Roles.NightExternal], config.networkId);
 
-  const relayURL = new URL(config.node.replace(/^http/, 'ws'));
-
-  const shieldedConfig = {
+  const configuration: DefaultConfiguration = {
     networkId: config.networkId,
     indexerClientConnection: {
       indexerHttpUrl: config.indexer,
       indexerWsUrl: config.indexerWS,
     },
     provingServerUrl: new URL(config.proofServer),
-    relayURL,
-  };
-
-  const unshieldedConfig = {
-    networkId: config.networkId,
-    indexerClientConnection: {
-      indexerHttpUrl: config.indexer,
-      indexerWsUrl: config.indexerWS,
-    },
-    txHistoryStorage: new InMemoryTransactionHistoryStorage(),
-  };
-
-  const dustConfig = {
-    networkId: config.networkId,
+    relayURL: new URL(config.node.replace(/^http/, 'ws')),
     costParameters: {
       additionalFeeOverhead: 300_000_000_000_000n,
       feeBlocksMargin: 5,
     },
-    indexerClientConnection: {
-      indexerHttpUrl: config.indexer,
-      indexerWsUrl: config.indexerWS,
-    },
-    provingServerUrl: new URL(config.proofServer),
-    relayURL,
+    txHistoryStorage: new InMemoryTransactionHistoryStorage(),
   };
 
-  const shieldedWallet = ShieldedWallet(shieldedConfig).startWithSecretKeys(shieldedSecretKeys);
-  const unshieldedWallet = UnshieldedWallet(unshieldedConfig).startWithPublicKey(
-    UnshieldedPublicKey.fromKeyStore(unshieldedKeystore),
-  );
-  const dustWallet = DustWallet(dustConfig).startWithSecretKey(
-    dustSecretKey,
-    ledger.LedgerParameters.initialParameters().dust,
-  );
-
-  const facade: WalletFacade = new WalletFacade(shieldedWallet, unshieldedWallet, dustWallet);
+  const facade: WalletFacade = await WalletFacade.init({
+    configuration,
+    shielded: (cfg) => ShieldedWallet(cfg).startWithSecretKeys(shieldedSecretKeys),
+    unshielded: (cfg) => UnshieldedWallet(cfg).startWithPublicKey(UnshieldedPublicKey.fromKeyStore(unshieldedKeystore)),
+    dust: (cfg) => DustWallet(cfg).startWithSecretKey(dustSecretKey, ledger.LedgerParameters.initialParameters().dust),
+  });
   await facade.start(shieldedSecretKeys, dustSecretKey);
 
   return { wallet: facade, shieldedSecretKeys, dustSecretKey, unshieldedKeystore };
@@ -171,7 +146,7 @@ export const displayWalletBalances = async (walletContext: WalletContext, config
   const state = await Rx.firstValueFrom(walletContext.wallet.state());
   const unshielded = state.unshielded?.balances[ledger.nativeToken().raw] ?? 0n;
   const shielded = state.shielded?.balances[ledger.nativeToken().raw] ?? 0n;
-  const dust = state.dust?.walletBalance(new Date()) ?? 0n;
+  const dust = state.dust?.balance(new Date()) ?? 0n;
 
   const unshieldedAddr = walletContext.unshieldedKeystore.getBech32Address().asString();
   const shieldedAddr = MidnightBech32m.encode(config.networkId, state.shielded.address).asString();
@@ -200,7 +175,7 @@ export const registerNightForDust = async (walletContext: WalletContext): Promis
   if (unregisteredNightUtxos.length === 0) {
     logger.info('No unshielded Night UTXOs available for dust registration, or all are already registered');
 
-    const dustBalance = state.dust?.walletBalance(new Date()) ?? 0n;
+    const dustBalance = state.dust?.balance(new Date()) ?? 0n;
     logger.info(`Current dust balance: ${dustBalance}`);
 
     return dustBalance > 0n;
@@ -228,10 +203,10 @@ export const registerNightForDust = async (walletContext: WalletContext): Promis
       walletContext.wallet.state().pipe(
         Rx.throttleTime(5_000),
         Rx.tap((s) => {
-          const dustBalance = s.dust?.walletBalance(new Date()) ?? 0n;
+          const dustBalance = s.dust?.balance(new Date()) ?? 0n;
           logger.info(`Dust balance: ${dustBalance}`);
         }),
-        Rx.filter((s) => (s.dust?.walletBalance(new Date()) ?? 0n) > 0n),
+        Rx.filter((s) => (s.dust?.balance(new Date()) ?? 0n) > 0n),
       ),
     );
 

--- a/standalone.yml
+++ b/standalone.yml
@@ -9,7 +9,7 @@ services:
       RUST_BACKTRACE: 'full'
   indexer:
     container_name: 'midnight-indexer'
-    image: 'midnightntwrk/indexer-standalone:3.0.0'
+    image: 'midnightntwrk/indexer-standalone:3.1.0'
     env_file: standalone.env.example
     ports:
       - '8088:8088'
@@ -27,7 +27,7 @@ services:
         condition: service_healthy
 
   node:
-    image: 'midnightntwrk/midnight-node:0.20.0'
+    image: 'midnightntwrk/midnight-node:0.21.0'
     container_name: 'midnight-node'
     ports:
       - '9944:9944'


### PR DESCRIPTION
- Update all @midnight-ntwrk packages to v2.0.0 compatibility matrix
- Replace WalletFacade constructor with static async WalletFacade.init()
- Unify three separate wallet configs into single DefaultConfiguration
- Use typed UnshieldedAddress for transfers instead of plain strings
- Rename dust wallet API: walletBalance() -> balance()
- Detect running local network on startup and prompt to reuse or restart
- Update standalone.yml Docker images (node 0.21.0, indexer 3.1.0)
- Add comprehensive SDK v1.0 to v2.0 migration guide